### PR TITLE
provided space for homeschool students

### DIFF
--- a/ZenCompetition.tex
+++ b/ZenCompetition.tex
@@ -107,7 +107,7 @@ Students will compete in independent categories for recognition awards. These aw
 
 \item \textbf{Performance:} Before proceeding into the obstacle course, the robot will be judged on a 90 second animation intended to hype up the crowd. At each save-point through the course another 90 second animation will be required. 
 
-\item \textbf{Eligibility:} High school and Jr High school students affiliated with public schools or not-for-profit private schools. Pay-to-play organizations are explicitly forbidden, all students must be able to join teams without a per student cost borne by the students or their families. 
+\item \textbf{Eligibility:} High school and Jr High school students affiliated with public schools or not-for-profit private schools or personal households. Pay-to-play organizations are explicitly forbidden, all students must be able to join teams without a per student cost borne by the students or their families. 
 
 
 \item \textbf{Team Composition:} Teams can be 1-6 students. Each team member registers an email address with the team submission for automatic contribution allocation. Teams must have at least on adult coach to register for events. Teams may consist of students from any eligible organization and need not all be from a single organization.  


### PR DESCRIPTION
Given the wording, "all students must be able to join teams without a per student cost borne by the students or their families" serves to prevent rent-extractive teams from existing by just claiming to be unions of personal households.